### PR TITLE
Fix callback_data handling

### DIFF
--- a/handlers/filter.py
+++ b/handlers/filter.py
@@ -1,4 +1,5 @@
 from telegram import Update, InlineKeyboardMarkup, InlineKeyboardButton
+from utils import safe_callback_data
 from telegram.ext import ContextTypes, ConversationHandler
 import logging
 from datetime import datetime, timedelta
@@ -167,15 +168,15 @@ async def show_filters(update: Update, context: ContextTypes.DEFAULT_TYPE):
         # ----------- КНОПКИ ДЕЙСТВИЙ -----------
         keyboard = [
             [
-                InlineKeyboardButton("✅ Уже заменил", callback_data=f"filter_replaced_{f.id}"),
-                InlineKeyboardButton("❌ Удалить", callback_data=f"filter_delete_{f.id}")
+                InlineKeyboardButton("✅ Уже заменил", callback_data=safe_callback_data(f"filter_replaced_{f.id}")),
+                InlineKeyboardButton("❌ Удалить", callback_data=safe_callback_data(f"filter_delete_{f.id}"))
             ],
             [
-                InlineKeyboardButton("ℹ️ Описание", callback_data=f"hint_{f.type}"),
-                InlineKeyboardButton("✏️ Переименовать", callback_data=f"rename_filter_{f.id}")
+                InlineKeyboardButton("ℹ️ Описание", callback_data=safe_callback_data(f"hint_{f.type}")),
+                InlineKeyboardButton("✏️ Переименовать", callback_data=safe_callback_data(f"rename_filter_{f.id}"))
             ],
             [
-                InlineKeyboardButton("📸 Добавить фото", callback_data=f"add_photo_{f.id}")
+                InlineKeyboardButton("📸 Добавить фото", callback_data=safe_callback_data(f"add_photo_{f.id}"))
             ]
         ]
 
@@ -193,8 +194,8 @@ async def show_filters(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 photos_list = photos
         if len(photos_list) > 0:
             keyboard.append([
-                InlineKeyboardButton("👁 Смотреть фото", callback_data=f"view_photos_{f.id}"),
-                InlineKeyboardButton("🗑 Удалить фото", callback_data=f"del_photo_{f.id}")
+                InlineKeyboardButton("👁 Смотреть фото", callback_data=safe_callback_data(f"view_photos_{f.id}")),
+                InlineKeyboardButton("🗑 Удалить фото", callback_data=safe_callback_data(f"del_photo_{f.id}"))
             ])
             text += f"\n📸 Есть фото: {len(photos_list)}"
 
@@ -207,7 +208,7 @@ async def show_filters(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await update.effective_message.reply_text(
         "Выберите дальнейшее действие:",
         reply_markup=InlineKeyboardMarkup([
-            [InlineKeyboardButton("🔙 В меню", callback_data="back_to_menu")]
+            [InlineKeyboardButton("🔙 В меню", callback_data=safe_callback_data("back_to_menu"))]
         ])
     )
     return ConversationHandler.END

--- a/handlers/filter_action.py
+++ b/handlers/filter_action.py
@@ -1,6 +1,7 @@
 from database import async_session, Filter
 from sqlalchemy import select
 from telegram import InlineKeyboardMarkup, InlineKeyboardButton, Update
+from utils import safe_callback_data
 from telegram.ext import ConversationHandler, ContextTypes
 from datetime import datetime, timezone
 import logging
@@ -81,12 +82,24 @@ async def filter_action_handler(update: Update, context: ContextTypes.DEFAULT_TY
                     )
                     keyboard = [
                         [
-                            InlineKeyboardButton("✅ Уже заменил", callback_data=f"filter_replaced_{filt.id}"),
-                            InlineKeyboardButton("❌ Удалить", callback_data=f"filter_delete_{filt.id}")
+                            InlineKeyboardButton(
+                                "✅ Уже заменил",
+                                callback_data=safe_callback_data(f"filter_replaced_{filt.id}")
+                            ),
+                            InlineKeyboardButton(
+                                "❌ Удалить",
+                                callback_data=safe_callback_data(f"filter_delete_{filt.id}")
+                            )
                         ],
                         [
-                            InlineKeyboardButton("📸 Добавить фото", callback_data=f"add_photo_{filt.id}"),
-                            InlineKeyboardButton("✏️ Переименовать", callback_data=f"rename_filter_{filt.id}")
+                            InlineKeyboardButton(
+                                "📸 Добавить фото",
+                                callback_data=safe_callback_data(f"add_photo_{filt.id}")
+                            ),
+                            InlineKeyboardButton(
+                                "✏️ Переименовать",
+                                callback_data=safe_callback_data(f"rename_filter_{filt.id}")
+                            )
                         ]
                     ]
                     markup = InlineKeyboardMarkup(keyboard)

--- a/tests/test_callback_data.py
+++ b/tests/test_callback_data.py
@@ -1,0 +1,22 @@
+import pytest
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from utils import safe_callback_data
+
+@pytest.mark.parametrize("value", [
+    123,
+    "", 
+    None,
+    "a"*70,
+    {"k":"v"},
+    "тест",
+    "valid_123",
+])
+def test_safe_callback_data(value):
+    result = safe_callback_data(value)
+    assert isinstance(result, str)
+    assert result
+    assert len(result.encode('utf-8')) <= 64
+    assert all(c.isalnum() or c in "_-" for c in result)
+


### PR DESCRIPTION
## Summary
- sanitize callback_data values using new `safe_callback_data`
- log callback_data values before sending
- use helper in filter-related keyboards
- add a simple unit test for the helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'telegram')*
- `pip install -r requirements.txt` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6877af8b25a08324a67236d5e9bd11b2