### PR TITLE
Fix syntax errors in handlers

### DIFF
--- a/handlers/common.py
+++ b/handlers/common.py
@@ -46,16 +46,16 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
                 "⚠️ Не удалось зарегистрировать вас. Попробуйте позже.")
             return ConversationHandler.END
 
-    if is_new:
-        await _send_clean_message(
-            update,
-            context,
-            "Добро пожаловать! Нажмите кнопку ниже, чтобы начать работу.",
-            reply_markup=InlineKeyboardMarkup([
-                [InlineKeyboardButton("Начать", callback_data="show_menu")]
-            ])
-        )
-        return ConversationHandler.END
+        if is_new:
+            await _send_clean_message(
+                update,
+                context,
+                "Добро пожаловать! Нажмите кнопку ниже, чтобы начать работу.",
+                reply_markup=InlineKeyboardMarkup([
+                    [InlineKeyboardButton("Начать", callback_data="show_menu")]
+                ])
+            )
+            return ConversationHandler.END
 
         text = _main_menu_text(user)
         await _send_clean_message(update, context, text, reply_markup=get_main_inline_keyboard())
@@ -109,44 +109,44 @@ async def handle_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.callback_query.answer()
         data = update.callback_query.data
 
-    if data == "show":
-        from handlers.filter import show_filters
-        return await show_filters(update, context)
+        if data == "show":
+            from handlers.filter import show_filters
+            return await show_filters(update, context)
+        
+        if data == "profile":
+            from handlers.profile import profile
+            return await profile(update, context)
 
-    if data == "profile":
-        from handlers.profile import profile
-        return await profile(update, context)
+        if data == "referral":
+            uid = update.callback_query.from_user.id
+            await update.callback_query.edit_message_text(
+                f"🎁 Пригласите друзей — и получите бонусы!\n"
+                f"Ваша ссылка: https://t.me/YOUR_BOT?start=ref%3D{uid}"
+            )
+            return ConversationHandler.END
 
-    if data == "referral":
-        uid = update.callback_query.from_user.id
-        await update.callback_query.edit_message_text(
-            f"🎁 Пригласите друзей — и получите бонусы!\n"
-            f"Ваша ссылка: https://t.me/YOUR_BOT?start=ref%3D{uid}"
-        )
-        return ConversationHandler.END
-
-    # При выборе "Добавить фильтр" — запускаем сценарий выбора фильтра
-    if data == "register":
-        from handlers.my_calendar import start_add_filter
-        return await start_add_filter(update, context)
-    
-
-    # Если выбрали конкретный тип фильтра — запускаем сценарий с датой
-    from constants import MAIN_LABELS
-    if data in MAIN_LABELS.keys():
-        from handlers.filter import filter_choose_callback
-        return await filter_choose_callback(update, context)
-
-    # Подсказки (ℹ️) и подробности о фильтрах
-    if data.startswith("hint_") or data.startswith("filter_more_"):
-        from handlers.filter import filter_hint_handler
-        return await filter_hint_handler(update, context)
-
-    if data.startswith("filter_scheme_"):
-        from handlers.filter import filter_scheme_handler
-        return await filter_scheme_handler(update, context)
-
-    # Остальные неизвестные callback_data
+        # При выборе "Добавить фильтр" — запускаем сценарий выбора фильтра
+        if data == "register":
+            from handlers.my_calendar import start_add_filter
+            return await start_add_filter(update, context)
+        
+        
+        # Если выбрали конкретный тип фильтра — запускаем сценарий с датой
+        from constants import MAIN_LABELS
+        if data in MAIN_LABELS.keys():
+            from handlers.filter import filter_choose_callback
+            return await filter_choose_callback(update, context)
+        
+        # Подсказки (ℹ️) и подробности о фильтрах
+        if data.startswith("hint_") or data.startswith("filter_more_"):
+            from handlers.filter import filter_hint_handler
+            return await filter_hint_handler(update, context)
+        
+        if data.startswith("filter_scheme_"):
+            from handlers.filter import filter_scheme_handler
+            return await filter_scheme_handler(update, context)
+        
+        # Остальные неизвестные callback_data
         logging.warning(f"Неизвестный callback_data: {data}")
         await update.callback_query.answer("Неизвестная команда.", show_alert=True)
         return ConversationHandler.END
@@ -220,8 +220,8 @@ async def show_menu_callback(update: Update, context: ContextTypes.DEFAULT_TYPE)
     return ConversationHandler.END
 
 async def support_ai(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    await update.callback_query.answer()
-    await update.callback_query.edit_message_text(
+        await update.callback_query.answer()
+        await update.callback_query.edit_message_text(
         "🤖 Здесь вы можете узнать:\n"
         "• Как выбрать фильтр\n"
         "• Где купить фильтр\n"
@@ -230,4 +230,4 @@ async def support_ai(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "Просто напишите свой вопрос, подскажу и помогу с выбором.\n\n"
         "Если нужна персональная консультация — напишите нашему менеджеру: @vkup25"
     )
-    return ConversationHandler.END
+        return ConversationHandler.END


### PR DESCRIPTION
## Summary
- fix unmatched `try` blocks in `handlers/common.py`
- normalize indentation for all handler functions

## Testing
- `python -m py_compile handlers/common.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'telegram')*

------
https://chatgpt.com/codex/tasks/task_e_6877f8d221f483248e69b7fbe3a88e1f