### PR TITLE
Fix duplicate start handler

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -117,7 +117,6 @@ filter_add_conv = ConversationHandler(
         CommandHandler("cancel", cancel),
         CallbackQueryHandler(main_menu_callback, pattern="^main_menu$"),
         CallbackQueryHandler(cancel_callback, pattern="^cancel$"),
-        CommandHandler("start", start),
     ]
 )
 
@@ -134,7 +133,6 @@ service_conv = ConversationHandler(
         CommandHandler("cancel", cancel),
         CallbackQueryHandler(cancel_callback, pattern="^cancel$"),
         CallbackQueryHandler(main_menu_callback, pattern="^main_menu$"),
-        CommandHandler("start", start)
     ]
 )
 
@@ -170,7 +168,6 @@ def main():
 
 
     # --- Handlers ---
-    app.add_handler(CommandHandler("start", start))
     app.add_handler(reg_conv)
     app.add_handler(phone_conv)
     app.add_handler(add_filter_photo_conv)

--- a/handlers/common.py
+++ b/handlers/common.py
@@ -1,5 +1,6 @@
 import random
 import logging
+from datetime import datetime
 from telegram import Update, InlineKeyboardMarkup, InlineKeyboardButton
 from telegram.ext import ContextTypes, ConversationHandler
 from constants import (
@@ -22,11 +23,17 @@ def _main_menu_text(user) -> str:
     )
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-    print(
-        f"/start called! chat_id={update.effective_chat.id} "
-        f"message={getattr(update.message, 'text', None)}"
+    user_id = getattr(update.effective_user, "id", None)
+    chat_id = getattr(update.effective_chat, "id", None)
+    msg_id = getattr(update.effective_message, "message_id", None)
+    start_ts = datetime.now().isoformat()
+    logging.debug(
+        "start enter: user=%s chat=%s msg=%s time=%s",
+        user_id,
+        chat_id,
+        msg_id,
+        start_ts,
     )
-    logging.debug("start called: update=%r", update)
     try:
         user = update.effective_user
         if update.message:
@@ -69,6 +76,14 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         if update.effective_message:
             await update.effective_message.reply_text("Произошла ошибка. Попробуйте позже.")
         return ConversationHandler.END
+    finally:
+        logging.debug(
+            "start exit: user=%s chat=%s msg=%s time=%s",
+            user_id,
+            chat_id,
+            msg_id,
+            datetime.now().isoformat(),
+        )
 
 async def clear_history(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Удаляет последние сообщения бота по команде /clear"""

--- a/handlers/crm_handlers.py
+++ b/handlers/crm_handlers.py
@@ -43,7 +43,6 @@ crm_conv_handler = ConversationHandler(
     },
     fallbacks=[
         CommandHandler('cancel', cancel),
-        CommandHandler('start', start)
     ],
     per_message=False,
 )

--- a/handlers/filter_photo.py
+++ b/handlers/filter_photo.py
@@ -343,8 +343,7 @@ add_filter_photo_conv = ConversationHandler(
         ]
     },
     fallbacks=[
-        CommandHandler("done", finish_photo),
-        CommandHandler("start", start)
+        CommandHandler("done", finish_photo)
     ],
     allow_reentry=True
 )

--- a/handlers/know_filter.py
+++ b/handlers/know_filter.py
@@ -71,6 +71,5 @@ know_filter_conv = ConversationHandler(
     },
     fallbacks=[
         CallbackQueryHandler(cancel_know_filter, pattern="^cancel_know_filter$"),
-        CommandHandler("start", start)
     ]
 )

--- a/handlers/my_calendar.py
+++ b/handlers/my_calendar.py
@@ -278,6 +278,5 @@ reg_conv = ConversationHandler(
     fallbacks=[
         CallbackQueryHandler(back_to_menu_callback, pattern="^back_to_menu$"),
         CallbackQueryHandler(cancel_calendar_handler, pattern="^calendar_cancel$"),
-        CommandHandler("start", start)
     ],
 )

--- a/handlers/payments.py
+++ b/handlers/payments.py
@@ -63,7 +63,6 @@ payments_conv = ConversationHandler(
     fallbacks=[
         MessageHandler(filters.Regex(f"^{CANCEL_BUTTON}$"), payment_cancel),
         CallbackQueryHandler(payment_cancel, pattern=f"^{CANCEL_BUTTON}$"),
-        CommandHandler("start", start)
     ],
     allow_reentry=True
 )

--- a/handlers/profile.py
+++ b/handlers/profile.py
@@ -153,7 +153,6 @@ phone_conv = ConversationHandler(
     fallbacks=[
         CommandHandler("cancel", cancel_phone),
         CallbackQueryHandler(cancel_phone, pattern="^back_to_menu$"),
-        CommandHandler("start", start)
     ],
     per_message=False
 )

--- a/tests/test_start_handler.py
+++ b/tests/test_start_handler.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from telegram.ext import CommandHandler
+
+from bot import filter_add_conv, service_conv
+from handlers.my_calendar import reg_conv
+from handlers.filter_photo import add_filter_photo_conv
+from handlers.profile import phone_conv
+from handlers.know_filter import know_filter_conv
+from handlers.payments import payments_conv
+from handlers.crm_handlers import crm_conv_handler
+
+
+def _has_start_handler(conv):
+    return any(isinstance(h, CommandHandler) and "start" in h.commands for h in conv.fallbacks)
+
+
+def test_no_start_in_conversation_fallbacks():
+    conversations = [
+        reg_conv,
+        filter_add_conv,
+        service_conv,
+        add_filter_photo_conv,
+        phone_conv,
+        know_filter_conv,
+        payments_conv,
+        crm_conv_handler,
+    ]
+    assert all(not _has_start_handler(c) for c in conversations)


### PR DESCRIPTION
## Summary
- remove redundant CommandHandler("start") fallbacks
- add debug logs in `start`
- unit test ensures no `CommandHandler('start')` in fallbacks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878c49f3d1c8324a4ef805947b5282b