### PR TITLE
Fix /start handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ If the bot fails to start with an `InvalidToken` error:
 3. Restart the bot after updating the token.
 4. Check the logs for a message about polling starting. Sending `/start` should trigger a greeting.
 
+The bot registers a dedicated `/start` command via a `CommandHandler`. Make sure
+the token is provided through the `.env` file so the handler is initialized
+correctly and you see a `sendMessage` entry in the log after using `/start`.
+
 For quick diagnostics you can run a minimal bot:
 
 ```bash

--- a/bot.py
+++ b/bot.py
@@ -221,6 +221,8 @@ def main():
     app.add_handler(CommandHandler("my_photos", show_filter_photos))
     app.add_handler(CommandHandler("edit_phone", edit_phone))
     app.add_handler(CommandHandler("clear", clear_history))
+    # Регистрация базовой команды /start
+    app.add_handler(CommandHandler("start", start))
     app.add_handler(CallbackQueryHandler(handle_callback))
     app.add_error_handler(error_handler)
 


### PR DESCRIPTION
## Summary
- register `/start` command with the bot
- clarify `/start` logging and token usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878e39ed9c48324a8235099a1794116